### PR TITLE
[improve] Add light-mode GitHub stats images to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 <a href="https://github.com/kaovilai/github-stats">
 <img src="https://github.com/kaovilai/github-stats/blob/master/generated/overview.svg#gh-dark-mode-only" />
 <img src="https://github.com/kaovilai/github-stats/blob/master/generated/languages.svg#gh-dark-mode-only" />
+<img src="https://github.com/kaovilai/github-stats/blob/master/generated/overview.svg#gh-light-mode-only" />
+<img src="https://github.com/kaovilai/github-stats/blob/master/generated/languages.svg#gh-light-mode-only" />
 </a>
 
 <!-- work tracker - red hat login required to see -->


### PR DESCRIPTION
Show stats images in both dark and light GitHub themes. Previously only dark-mode variants were included, so visitors using light mode saw no stats images at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added light mode badge variants to the README for improved visibility and better support across light and dark theme environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaovilai/kaovilai/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->