### PR TITLE
[improve] fix: upgrade http to https in FUNDING.yml custom sponsor URL

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -9,4 +9,4 @@ community_bridge: # Replace with a single Community Bridge project-name e.g., cl
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
-custom: ["https://paypal.me/pkaov","https://venmo.com/code?user_id=2065666886598656219","https://cash.me/$tigpk","http://m.me/passawit"]# Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+custom: ["https://paypal.me/pkaov","https://venmo.com/code?user_id=2065666886598656219","https://cash.me/$tigpk","https://m.me/passawit"] # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
The Messenger link used http:// instead of https://, which could expose visitors to downgrade attacks. Upgraded to https://.