### PR TITLE
Add LLM policy on transparent AI-assisted contributions

### DIFF
--- a/llm_policy.md
+++ b/llm_policy.md
@@ -1,0 +1,38 @@
+# LLM Policy
+
+This document describes how I, Tiger Kaovilai ([@kaovilai](https://github.com/kaovilai)), use AI/LLM tooling when contributing to other repositories. It exists so maintainers know what to expect from me before, during, and after a contribution.
+
+## Declaration
+
+- Some of my contributions (code, commits, and pull requests) may be **co-authored with AI**.
+- Some of my responses (issue comments, review replies, and discussion) may be **generated with AI**.
+
+When AI co-authors a commit, it is attributed via a `Co-authored-by:` trailer. When a response is AI-generated, I mark it inline, for example:
+
+> [!Note]
+> Responses generated with Claude
+
+If a repository prohibits the `Co-authored-by:` trailer, I will omit it. In those cases the repository often requires the pull request description to declare which AI was used, so the declaration will appear in the pull request description itself instead.
+
+## Commitment to transparency
+
+I am committed to being transparent about my use of AI:
+
+- **Attribution.** AI-assisted commits carry a `Co-authored-by:` trailer, and AI-generated comments/replies carry a visible note (see above).
+- **Disclosure on request.** If a maintainer asks whether AI was involved in a given contribution, I will answer honestly.
+- **Sign-off and ownership.** I sign my commits (`git commit -s`, DCO) and take full responsibility for everything I submit, regardless of how it was drafted.
+
+## Human review
+
+Every pull request and reply I send — **including those that carry a note indicating an AI-generated response** — is thoroughly reviewed by me before it goes out. The AI note appears on *every* comment my AI generates, even ones I have manually reviewed; it signals *how the draft was produced*, not that the content went out unreviewed. I read, verify, and stand behind each contribution.
+
+This level of disclosure goes beyond what many other people do when using AI. Plenty of contributors use AI without any attribution at all; my aim is to be more transparent than the norm, not less.
+
+## Respecting repository policies
+
+I respect each repository's own rules on AI usage.
+
+- If a repository publishes an `LLM_POLICY` (or equivalent) that **prohibits any meaningful use of AI**, I will most likely **not contribute** to that repository, rather than attempt to work around the policy.
+- Where a repository permits AI use under certain conditions (disclosure, attribution, review, etc.), I will follow those conditions.
+
+If you maintain a repository and have questions about how I work, please reach out before or during review — I'm happy to clarify.

--- a/llm_policy.md
+++ b/llm_policy.md
@@ -5,11 +5,11 @@ This document describes how I, Tiger Kaovilai ([@kaovilai](https://github.com/ka
 ## Declaration
 
 - Some of my contributions (code, commits, and pull requests) may be **co-authored with AI**.
-- Some of my responses (issue comments, review replies, and discussion) may be **generated with AI**.
+- Some of my responses (issue comments, review replies, and discussions) may be **generated with AI**.
 
 When AI co-authors a commit, it is attributed via a `Co-authored-by:` trailer. When a response is AI-generated, I mark it inline, for example:
 
-> [!Note]
+> [!NOTE]
 > Responses generated with Claude
 
 If a repository prohibits the `Co-authored-by:` trailer, I will omit it. In those cases the repository often requires the pull request description to declare which AI was used, so the declaration will appear in the pull request description itself instead.


### PR DESCRIPTION
Adds `llm_policy.md` describing how I contribute to other repositories with transparency about AI/LLM use.

It covers:
- A declaration that some contributions may be AI co-authored and some responses AI-generated, with `Co-authored-by:` trailers and inline `> [!Note]` markers.
- The fact that the `Co-authored-by:` trailer may be omitted where a repository prohibits it, in which case the AI declaration moves to the pull request description.
- My commitment to transparency (attribution, disclosure on request, DCO sign-off and ownership).
- That every PR and reply — including ones carrying an AI-generated note — is thoroughly reviewed before it goes out, and that the note appears on every AI-generated comment even when manually reviewed.
- That if a repository's LLM policy prohibits any meaningful use of AI, I will most likely not contribute there.

This policy is inspired by repository AI-usage restrictions such as those on Buildah/Podman (e.g. https://github.com/podman-container-tools/buildah/pull/6854#issuecomment-4709767869, which points to that project's `LLM_POLICY.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contributor documentation defining AI/LLM tooling policies and practices for the project. Includes detailed guidelines for when contributions may be co-authored or AI-generated, proper attribution conventions, personal code review commitments and requirements before submission, transparency and disclosure standards, responsibility practices, and alignment with repository-specific AI usage policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->