### PR TITLE
Add agentic workflow exception to LLM policy for my own repos

### DIFF
--- a/llm_policy.md
+++ b/llm_policy.md
@@ -28,6 +28,15 @@ Every pull request and reply I send — **including those that carry a note indi
 
 This level of disclosure goes beyond what many other people do when using AI. Plenty of contributors use AI without any attribution at all; my aim is to be more transparent than the norm, not less.
 
+## Exception: agentic workflows on my own repositories
+
+The human-review commitment above applies to my contributions to **other people's repositories**. I run an exception in **my own repositories** where I am experimenting with **agentic workflows** — for example [GitHub Agentic Workflows (GH-AW)](https://github.com/githubnext/gh-aw). GH-AW is the current experiment, but this exception applies equally to **any other agentic workflow tooling I may adopt in the future**, not just GH-AW.
+
+- This exception is limited to **repositories I own** (e.g. under [`github.com/kaovilai`](https://github.com/kaovilai)). It does **not** apply to repositories owned by others that I contribute to — those always receive the full human review described above.
+- Within these experiments, AI agents may open issues, commits, and pull requests **autonomously**, and some of that output may be merged with **lighter human review than I apply elsewhere** — that is the point of the experiment.
+- AI-produced contributions from these workflows remain attributed (via `Co-authored-by:` trailers and/or AI-generated notes) so it stays clear which work came from an agent.
+- I remain responsible for everything that lands in my own repositories.
+
 ## Respecting repository policies
 
 I respect each repository's own rules on AI usage.


### PR DESCRIPTION
## Why

My LLM policy commits to thorough human review of every contribution. That commitment is the right default for work on other people's repositories, but it conflicts with the agentic workflow experiments I run on my own repos, where the whole point is to let AI agents operate autonomously with lighter human review.

## What changed

Adds an "Exception: agentic workflows on my own repositories" section to `llm_policy.md` that:

- Scopes the exception strictly to repositories I own (`github.com/kaovilai`), explicitly excluding others' repos I contribute to, which still get full human review.
- Names [GH-AW (GitHub Agentic Workflows)](https://github.com/githubnext/gh-aw) as the current experiment, while making clear the same exception applies to any future agentic workflow tooling, not just GH-AW.
- Notes that agents may open issues, commits, and PRs autonomously and that some output may merge with lighter review.
- Preserves attribution (`Co-authored-by:` trailers / AI-generated notes) and my ownership of everything that lands.

Documentation-only change to a single file.